### PR TITLE
21 09 handle longer qvalues

### DIFF
--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 #
 # Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
-#
+# 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+# 
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-#
+# 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,98 +30,98 @@ module HTTP
 		module Languages
 			# https://tools.ietf.org/html/rfc3066#section-2.1
 			LOCALE = /\*|[A-Z]{1,8}(-[A-Z0-9]{1,8})*/i
-
+			
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
 			QVALUE = /0(\.[0-9]{0,})?|1(\.[0]{0,})?/
 
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/
-
+			
 			# Provides an efficient data-structure for matching the Accept-Languages header to set of available locales according to https://tools.ietf.org/html/rfc7231#section-5.3.5 and https://tools.ietf.org/html/rfc4647#section-2.3
 			class Locales
 				def self.expand(locale, into)
 					parts = locale.split('-')
-
+					
 					while parts.size > 0
 						key = parts.join('-')
-
+						
 						into[key] ||= locale
-
+						
 						parts.pop
 					end
 				end
-
+				
 				def initialize(names)
 					@names = names
 					@patterns = {}
-
+					
 					@names.each{|name| self.class.expand(name, @patterns)}
-
+					
 					self.freeze
 				end
-
+				
 				def freeze
 					@names.freeze
 					@patterns.freeze
-
+					
 					super
 				end
-
+				
 				def each(&block)
 					return to_enum unless block_given?
-
+					
 					@names.each(&block)
 				end
-
+				
 				attr :names
 				attr :patterns
-
+				
 				# Returns the intersection of others retaining order.
 				def & languages
 					languages.collect{|language_range| @patterns[language_range.locale]}.compact
 				end
-
+				
 				def include? locale_name
 					@patterns.include? locale_name
 				end
-
+				
 				def join(*args)
 					@names.join(*args)
 				end
-
+				
 				def + others
 					self.class.new(@names + others.to_a)
 				end
-
+				
 				def to_a
 					@names
 				end
 			end
-
+			
 			LanguageRange = Struct.new(:locale, :q) do
 				def quality_factor
 					(q || 1.0).to_f
 				end
-
+				
 				def self.parse(scanner)
 					return to_enum(:parse, scanner) unless block_given?
-
+					
 					while scanner.scan(LANGUAGE_RANGE)
 						yield self.new(scanner[:locale], scanner[:q])
-
+						
 						# Are there more?
 						break unless scanner.scan(/\s*,\s*/)
 					end
-
+					
 					raise ParseError.new("Could not parse entire string!") unless scanner.eos?
 				end
 			end
-
+			
 			def self.parse(text)
 				scanner = StringScanner.new(text)
-
+				
 				languages = LanguageRange.parse(scanner)
-
+				
 				return Sort.by_quality_factor(languages)
 			end
 		end

--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -33,7 +33,7 @@ module HTTP
 			
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
 			QVALUE = /0(\.[0-9]{0,})?|1(\.[0]{0,})?/
-      
+			
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/
 			

--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 #
 # Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,98 +30,98 @@ module HTTP
 		module Languages
 			# https://tools.ietf.org/html/rfc3066#section-2.1
 			LOCALE = /\*|[A-Z]{1,8}(-[A-Z0-9]{1,8})*/i
-			
+
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
 			QVALUE = /0(\.[0-9]{0,3})?|1(\.[0]{0,3})?/
-			
+
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/
-			
+
 			# Provides an efficient data-structure for matching the Accept-Languages header to set of available locales according to https://tools.ietf.org/html/rfc7231#section-5.3.5 and https://tools.ietf.org/html/rfc4647#section-2.3
 			class Locales
 				def self.expand(locale, into)
 					parts = locale.split('-')
-					
+
 					while parts.size > 0
 						key = parts.join('-')
-						
+
 						into[key] ||= locale
-						
+
 						parts.pop
 					end
 				end
-				
+
 				def initialize(names)
 					@names = names
 					@patterns = {}
-					
+
 					@names.each{|name| self.class.expand(name, @patterns)}
-					
+
 					self.freeze
 				end
-				
+
 				def freeze
 					@names.freeze
 					@patterns.freeze
-					
+
 					super
 				end
-				
+
 				def each(&block)
 					return to_enum unless block_given?
-					
+
 					@names.each(&block)
 				end
-				
+
 				attr :names
 				attr :patterns
-				
+
 				# Returns the intersection of others retaining order.
 				def & languages
 					languages.collect{|language_range| @patterns[language_range.locale]}.compact
 				end
-				
+
 				def include? locale_name
 					@patterns.include? locale_name
 				end
-				
+
 				def join(*args)
 					@names.join(*args)
 				end
-				
+
 				def + others
 					self.class.new(@names + others.to_a)
 				end
-				
+
 				def to_a
 					@names
 				end
 			end
-			
+
 			LanguageRange = Struct.new(:locale, :q) do
 				def quality_factor
 					(q || 1.0).to_f
 				end
-				
+
 				def self.parse(scanner)
 					return to_enum(:parse, scanner) unless block_given?
-					
+
 					while scanner.scan(LANGUAGE_RANGE)
 						yield self.new(scanner[:locale], scanner[:q])
-						
+
 						# Are there more?
 						break unless scanner.scan(/\s*,\s*/)
 					end
-					
+
 					raise ParseError.new("Could not parse entire string!") unless scanner.eos?
 				end
 			end
-			
+
 			def self.parse(text)
 				scanner = StringScanner.new(text)
-				
+
 				languages = LanguageRange.parse(scanner)
-				
+
 				return Sort.by_quality_factor(languages)
 			end
 		end

--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -32,7 +32,7 @@ module HTTP
 			LOCALE = /\*|[A-Z]{1,8}(-[A-Z0-9]{1,8})*/i
 			
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
-			QVALUE = /0(\.[0-9]{0,})?|1(\.[0]{0,})?/
+			QVALUE = /0(\.[0-9]{0,6})?|1(\.[0]{0,6})?/
 			
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/

--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -32,7 +32,7 @@ module HTTP
 			LOCALE = /\*|[A-Z]{1,8}(-[A-Z0-9]{1,8})*/i
 
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
-			QVALUE = /0(\.[0-9]{0,3})?|1(\.[0]{0,3})?/
+			QVALUE = /0(\.[0-9]{0,})?|1(\.[0]{0,})?/
 
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/

--- a/lib/http/accept/languages.rb
+++ b/lib/http/accept/languages.rb
@@ -33,7 +33,7 @@ module HTTP
 			
 			# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9
 			QVALUE = /0(\.[0-9]{0,})?|1(\.[0]{0,})?/
-
+      
 			# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 			LANGUAGE_RANGE = /(?<locale>#{LOCALE})(\s*;\s*q=(?<q>#{QVALUE}))?/
 			

--- a/spec/http/languages_spec.rb
+++ b/spec/http/languages_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 #
 # Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,48 +25,61 @@ require 'http/accept/languages'
 RSpec.describe HTTP::Accept::Languages do
 	it "should parse basic header" do
 		languages = HTTP::Accept::Languages.parse("da, en-gb;q=0.5, en;q=0.25")
-		
+
 		expect(languages[0].locale).to be == "da"
 		expect(languages[0].quality_factor).to be == 1.0
-		
+
 		expect(languages[1].locale).to be == "en-gb"
 		expect(languages[1].quality_factor).to be == 0.5
-		
+
 		expect(languages[2].locale).to be == "en"
 		expect(languages[2].quality_factor).to be == 0.25
 	end
-	
+
 	it "should order based on quality factor" do
 		languages = HTTP::Accept::Languages.parse("en-gb;q=0.25, en;q=0.5, en-us")
 		expect(languages.collect(&:locale)).to be == %w{en-us en en-gb}
-		
+
 		languages = HTTP::Accept::Languages.parse("en-us,en-gb;q=0.8,en;q=0.6,es-419")
 		expect(languages.collect(&:locale)).to be == %w{en-us es-419 en-gb en}
 	end
-	
+
 	it "should accept wildcard language" do
 		languages = HTTP::Accept::Languages.parse("*;q=0")
-		
+
 		expect(languages[0].locale).to be == "*"
 		expect(languages[0].quality_factor).to be == 0
 	end
-	
+
 	it "should preserve relative order" do
 		languages = HTTP::Accept::Languages.parse("en, de;q=0.5, jp;q=0.5")
-		
+
 		expect(languages[0].locale).to be == "en"
 		expect(languages[1].locale).to be == "de"
 		expect(languages[2].locale).to be == "jp"
 	end
-	
+
 	it "should parse with optional whitespace" do
 		languages = HTTP::Accept::Languages.parse("de, en-US; q=0.7, en ; q=0.3")
-		
+
 		expect(languages[0].locale).to be == "de"
 		expect(languages[1].locale).to be == "en-US"
 		expect(languages[2].locale).to be == "en"
 	end
-	
+
+  it "should accept quality factors up to 6 decimal places" do
+		languages = HTTP::Accept::Languages.parse("en;q=0.123456")
+
+		expect(languages[0].locale).to be == "en"
+		expect(languages[0].quality_factor).to be == 0.123456
+	end
+
+  it "should not accept quality factors with more than 6 decimal places" do
+		text = "en;q=0.1234567"
+
+    expect{HTTP::Accept::Languages.parse(text)}.to raise_error(HTTP::Accept::ParseError)
+	end
+
 	it "should not accept invalid input" do
 		[
 			"en;f=1", "de;jp",
@@ -80,46 +93,46 @@ end
 RSpec.describe HTTP::Accept::Languages::Locales do
 	# Specified by the server, content localizations that are actually available:
 	let(:locales) {HTTP::Accept::Languages::Locales.new(["en-us", "en-nz", "en-au"])}
-	
+
 	it "should filter and expand the requested locales" do
 		# Provided by the client:
 		languages = HTTP::Accept::Languages.parse("en-au, en")
-		
+
 		# The localized content which is best for this user:
 		expect(locales & languages).to be == ["en-au", "en-us"]
 	end
-	
+
 	it "it should filter the requested locale" do
 		languages = HTTP::Accept::Languages.parse("en-au")
 		expect(locales & languages).to be == ["en-au"]
 	end
-	
+
 	it "it should expand the requested locale" do
 		languages = HTTP::Accept::Languages.parse("en")
 		expect(locales & languages).to be == ["en-us"]
 	end
-	
+
 	it "should include all generic locales" do
 		expect(locales).to be_include "en-us"
 		expect(locales).to be_include "en-nz"
 		expect(locales).to be_include "en-au"
 		expect(locales).to be_include "en"
 	end
-	
+
 	it "can be joined into a string" do
 		expect(locales.join(',')).to be == "en-us,en-nz,en-au"
 	end
-	
+
 	it "can be added together" do
 		others = ['ja']
-		
+
 		expect(locales + others).to include('en', 'en-us', 'ja')
 	end
-	
+
 	it "can be converted to an array of names" do
 		expect(locales.to_a).to be == locales.names
 	end
-	
+
 	it "can be enumerated using each" do
 		expect(locales.each.to_a).to be == locales.names
 	end

--- a/spec/http/languages_spec.rb
+++ b/spec/http/languages_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe HTTP::Accept::Languages do
 		expect(languages[2].locale).to be == "en"
 	end
 
-  it "should accept quality factors up to 6 decimal places" do
+	it "should accept quality factors up to 6 decimal places" do
 		languages = HTTP::Accept::Languages.parse("en;q=0.123456")
 
 		expect(languages[0].locale).to be == "en"
 		expect(languages[0].quality_factor).to be == 0.123456
 	end
 
-  it "should not accept quality factors with more than 6 decimal places" do
+	it "should not accept quality factors with more than 6 decimal places" do
 		text = "en;q=0.1234567"
 
 		expect{HTTP::Accept::Languages.parse(text)}.to raise_error(HTTP::Accept::ParseError)

--- a/spec/http/languages_spec.rb
+++ b/spec/http/languages_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 #
 # Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
-#
+# 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+# 
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-#
+# 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,43 +25,43 @@ require 'http/accept/languages'
 RSpec.describe HTTP::Accept::Languages do
 	it "should parse basic header" do
 		languages = HTTP::Accept::Languages.parse("da, en-gb;q=0.5, en;q=0.25")
-
+		
 		expect(languages[0].locale).to be == "da"
 		expect(languages[0].quality_factor).to be == 1.0
-
+		
 		expect(languages[1].locale).to be == "en-gb"
 		expect(languages[1].quality_factor).to be == 0.5
-
+		
 		expect(languages[2].locale).to be == "en"
 		expect(languages[2].quality_factor).to be == 0.25
 	end
-
+	
 	it "should order based on quality factor" do
 		languages = HTTP::Accept::Languages.parse("en-gb;q=0.25, en;q=0.5, en-us")
 		expect(languages.collect(&:locale)).to be == %w{en-us en en-gb}
-
+		
 		languages = HTTP::Accept::Languages.parse("en-us,en-gb;q=0.8,en;q=0.6,es-419")
 		expect(languages.collect(&:locale)).to be == %w{en-us es-419 en-gb en}
 	end
-
+	
 	it "should accept wildcard language" do
 		languages = HTTP::Accept::Languages.parse("*;q=0")
-
+		
 		expect(languages[0].locale).to be == "*"
 		expect(languages[0].quality_factor).to be == 0
 	end
-
+	
 	it "should preserve relative order" do
 		languages = HTTP::Accept::Languages.parse("en, de;q=0.5, jp;q=0.5")
-
+		
 		expect(languages[0].locale).to be == "en"
 		expect(languages[1].locale).to be == "de"
 		expect(languages[2].locale).to be == "jp"
 	end
-
+	
 	it "should parse with optional whitespace" do
 		languages = HTTP::Accept::Languages.parse("de, en-US; q=0.7, en ; q=0.3")
-
+		
 		expect(languages[0].locale).to be == "de"
 		expect(languages[1].locale).to be == "en-US"
 		expect(languages[2].locale).to be == "en"
@@ -79,7 +79,7 @@ RSpec.describe HTTP::Accept::Languages do
 
     expect{HTTP::Accept::Languages.parse(text)}.to raise_error(HTTP::Accept::ParseError)
 	end
-
+	
 	it "should not accept invalid input" do
 		[
 			"en;f=1", "de;jp",
@@ -93,46 +93,46 @@ end
 RSpec.describe HTTP::Accept::Languages::Locales do
 	# Specified by the server, content localizations that are actually available:
 	let(:locales) {HTTP::Accept::Languages::Locales.new(["en-us", "en-nz", "en-au"])}
-
+	
 	it "should filter and expand the requested locales" do
 		# Provided by the client:
 		languages = HTTP::Accept::Languages.parse("en-au, en")
-
+		
 		# The localized content which is best for this user:
 		expect(locales & languages).to be == ["en-au", "en-us"]
 	end
-
+	
 	it "it should filter the requested locale" do
 		languages = HTTP::Accept::Languages.parse("en-au")
 		expect(locales & languages).to be == ["en-au"]
 	end
-
+	
 	it "it should expand the requested locale" do
 		languages = HTTP::Accept::Languages.parse("en")
 		expect(locales & languages).to be == ["en-us"]
 	end
-
+	
 	it "should include all generic locales" do
 		expect(locales).to be_include "en-us"
 		expect(locales).to be_include "en-nz"
 		expect(locales).to be_include "en-au"
 		expect(locales).to be_include "en"
 	end
-
+	
 	it "can be joined into a string" do
 		expect(locales.join(',')).to be == "en-us,en-nz,en-au"
 	end
-
+	
 	it "can be added together" do
 		others = ['ja']
-
+		
 		expect(locales + others).to include('en', 'en-us', 'ja')
 	end
-
+	
 	it "can be converted to an array of names" do
 		expect(locales.to_a).to be == locales.names
 	end
-
+	
 	it "can be enumerated using each" do
 		expect(locales.each.to_a).to be == locales.names
 	end

--- a/spec/http/languages_spec.rb
+++ b/spec/http/languages_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe HTTP::Accept::Languages do
   it "should not accept quality factors with more than 6 decimal places" do
 		text = "en;q=0.1234567"
 
-    expect{HTTP::Accept::Languages.parse(text)}.to raise_error(HTTP::Accept::ParseError)
+		expect{HTTP::Accept::Languages.parse(text)}.to raise_error(HTTP::Accept::ParseError)
 	end
 	
 	it "should not accept invalid input" do


### PR DESCRIPTION
## Description

The current implementation expects `qvalues` with at most 3 decimal places (e.g. q=0.001) which of course is correct in general. However, looks like some browsers send `qvalues` with longer decimal places; the below example was encountered by one of our products in the company I work at:
**"de,de-DE;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6, ag;q=0.0001"**

This string raises an exception **"Could not parse entire string!"** which we had to rescue from and provide a fallback locale.
The main issue can be noticed at the end of the string with `q=0.0001` which have 4 decimal places.

### Types of Changes
- Bug fix.

### Testing
- [ ] I tested my changes locally.
